### PR TITLE
Migrate away from compromised key and initialized vector

### DIFF
--- a/app/src/main/cpp/native-lib.c
+++ b/app/src/main/cpp/native-lib.c
@@ -8,7 +8,7 @@ JNIEXPORT jstring JNICALL
 Java_com_wallet_crypto_trustapp_controller_PasswordManager_getKeyStringFromNative( JNIEnv* env, jobject thiz )
 {
     // TODO: fill in your key - must be 32 bytes
-    const jstring key = "35TheTru5tWa11ets3cr3tK3y377123!";
+    const jstring key = "ThisIsNotTheKeyYoureLookingFor!!";
     return (*env)->NewStringUTF(env, key);
 }
 
@@ -16,6 +16,6 @@ JNIEXPORT jbyteArray JNICALL
 Java_com_wallet_crypto_trustapp_controller_PasswordManager_getIvStringFromNative( JNIEnv* env, jobject thiz )
 {
     // TODO: fill in your iv - must be 16 bytes
-    const jstring iv = "8201va0184a0md8i";
+    const jstring iv = "NorTheInitVector";
     return (*env)->NewStringUTF(env, iv);
 }

--- a/app/src/main/java/com/wallet/crypto/trustapp/controller/PasswordManager.java
+++ b/app/src/main/java/com/wallet/crypto/trustapp/controller/PasswordManager.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.util.Base64;
+import android.util.Log;
 
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidAlgorithmParameterException;
@@ -58,6 +59,12 @@ public final class PasswordManager {
     static {
         System.loadLibrary("native-lib");
     }
+
+    // These key and iv were compromised after being committed to the public github repo.
+    // To migrate old clients, we will first attempt to decrypt using these keys.
+    // TODO: remove once all 1.3.2 clients have upgraded
+    private final static String legacyKey = "35TheTru5tWa11ets3cr3tK3y377123!";
+    private final static String legacyIv = "8201va0184a0md8i";
 
     public static native String getKeyStringFromNative();
     public static native String getIvStringFromNative();
@@ -121,6 +128,18 @@ public final class PasswordManager {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         final byte[] encryptedPassword = Base64.decode(sharedPreferences.getString(address + "-pwd", null), Base64.DEFAULT);
 
+        // Attempt to decrypt using legacy key/iv to migrate old clients
+        // TODO: remove once all clients have upgraded from 1.3.2
+        SecretKey oldKey = new SecretKeySpec(legacyKey.getBytes("UTF-8"), "AES");
+        IvParameterSpec oldIv = new IvParameterSpec(legacyIv.getBytes("UTF-8"));
+        try {
+            final String decryptedPassword = decrypt(encryptedPassword, oldKey, oldIv);
+            return decryptedPassword;
+        } catch (Exception e) {
+            Log.e("PASSMAN", e.getMessage());
+        }
+
+        // If decryption fails, it is most likely because this is a new client
         // decrypt password
         SecretKey key = new SecretKeySpec(getKeyStringFromNative().getBytes("UTF-8"), "AES");
         IvParameterSpec iv = new IvParameterSpec(getIvStringFromNative().getBytes("UTF-8"));


### PR DESCRIPTION
Testing:
1. Created account using old key and iv
2. Changed key and iv, recompiled and upgraded
3. On backupc, confirmed that we're attempting to decrypt using legacy key and throwing exception:

11-13 07:37:26.264 30487-30487/com.wallet.crypto.trustapp E/PASSMAN: error:1e06b065:Cipher functions:EVP_DecryptFinal_ex:BAD_DECRYPT

4. And did a successful backup and delete - both of which require the secret password.

